### PR TITLE
Cache tree model training and evaluation

### DIFF
--- a/src/training/train_DT.py
+++ b/src/training/train_DT.py
@@ -1,78 +1,150 @@
-import os
-import joblib
-import numpy as np
-import json
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.metrics import classification_report, confusion_matrix, ConfusionMatrixDisplay, f1_score, roc_curve, roc_auc_score, precision_recall_curve
-import matplotlib.pyplot as plt
+"""Training and evaluation script for Decision Tree classifier with caching."""
 
-# ====== CONFIG ======
-DATA_PATH = 'data/processed/preprocessed_data_v4.pkl' 
-MODEL_SAVE_PATH = 'models/models_v4/model_dtree.pkl'
-RESULTS_DIR = 'outputs/results_v4/decisiontree'
+import json
+import os
+import time
+
+import joblib
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.metrics import (
+    ConfusionMatrixDisplay,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_recall_curve,
+    roc_auc_score,
+    roc_curve,
+)
+from sklearn.tree import DecisionTreeClassifier
+
+DATA_PATH = "data/processed/preprocessed_data_v4.pkl"
+MODEL_SAVE_PATH = "models/models_v4/model_dtree.pkl"
+RESULTS_DIR = "outputs/results_v4/decisiontree"
+PREDICTIONS_PATH = os.path.join(RESULTS_DIR, "predictions.npz")
+REPORT_PATH = os.path.join(RESULTS_DIR, "classification_report.json")
+
 os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
 os.makedirs(RESULTS_DIR, exist_ok=True)
 
-# ====== LOAD DATA ======
-X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
-# Có thể concat train + val
-X_tr = np.concatenate([X_train, X_val], axis=0)
-y_tr = np.concatenate([y_train, y_val], axis=0)
+SEED = 42
 
-# ====== TRAIN Decision Tree ======
-dtree = DecisionTreeClassifier(
-    max_depth=None,       # Hoặc set max_depth=5,... nếu muốn regularize
-    min_samples_split=2,
-    random_state=42
-)
-dtree.fit(X_tr, y_tr)
-joblib.dump(dtree, MODEL_SAVE_PATH)
 
-# ====== EVALUATE Decision Tree ======
-preds = dtree.predict(X_test)
-probs = dtree.predict_proba(X_test)[:, 1] if len(dtree.classes_) > 1 else np.zeros_like(preds)
+def load_data():
+    return joblib.load(DATA_PATH)
 
-# Classification report
-report = classification_report(y_test, preds, output_dict=True)
-with open(f"{RESULTS_DIR}/classification_report.json", "w") as f:
-    json.dump(report, f, indent=4)
-print(classification_report(y_test, preds))
-print("F1-micro:", f1_score(y_test, preds, average='micro'))
 
-# Confusion Matrix (normalized as percentage)
-cm = confusion_matrix(y_test, preds, normalize='true')
-disp = ConfusionMatrixDisplay(confusion_matrix=cm)
-disp.plot(values_format='.2%')
-plt.title("Confusion Matrix - Decision Tree")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
-plt.close()
+def train_model(X_tr: np.ndarray, y_tr: np.ndarray) -> tuple[DecisionTreeClassifier, int]:
+    model = DecisionTreeClassifier(
+        max_depth=None,
+        min_samples_split=2,
+        random_state=SEED,
+    )
+    start = time.perf_counter_ns()
+    model.fit(X_tr, y_tr)
+    end = time.perf_counter_ns()
+    joblib.dump(model, MODEL_SAVE_PATH)
+    return model, end - start
 
-# ROC Curve (chỉ vẽ nếu có xác suất class 1)
-if len(dtree.classes_) > 1:
-    fpr, tpr, _ = roc_curve(y_test, probs)
-    auc_score = roc_auc_score(y_test, probs)
-    plt.figure()
-    plt.plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
-    plt.plot([0, 1], [0, 1], linestyle='--', color='gray')
-    plt.xlabel('False Positive Rate')
-    plt.ylabel('True Positive Rate')
-    plt.title('ROC Curve - Decision Tree')
-    plt.legend()
-    plt.savefig(f"{RESULTS_DIR}/roc_curve.pdf")
-    plt.savefig(f"{RESULTS_DIR}/roc_curve.svg")
+
+def evaluate_model(
+    model: DecisionTreeClassifier, X_test: np.ndarray, y_test: np.ndarray, train_time_ns: int
+) -> int:
+    start = time.perf_counter_ns()
+    preds = model.predict(X_test)
+    probs = (
+        model.predict_proba(X_test)[:, 1]
+        if hasattr(model, "predict_proba") and len(model.classes_) > 1
+        else np.zeros_like(preds, dtype=float)
+    )
+    end = time.perf_counter_ns()
+    eval_time_ns = end - start
+
+    np.savez(PREDICTIONS_PATH, y_test=y_test, preds=preds, probs=probs)
+
+    report = classification_report(y_test, preds, output_dict=True)
+    report["timing"] = {
+        "train_time_ns": train_time_ns,
+        "evaluate_time_ns": eval_time_ns,
+    }
+    with open(REPORT_PATH, "w") as f:
+        json.dump(report, f, indent=4)
+
+    print("=== Decision Tree Classification Report ===")
+    print(classification_report(y_test, preds))
+    print("F1-micro:", f1_score(y_test, preds, average="micro"))
+    print(f"Train time: {train_time_ns / 1e9:.4f}s  ({train_time_ns} ns)")
+    print(f"Eval time:  {eval_time_ns / 1e9:.4f}s  ({eval_time_ns} ns)")
+
+    cm = confusion_matrix(y_test, preds, normalize="true")
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm)
+    disp.plot(values_format=".2%")
+    plt.title("Confusion Matrix - Decision Tree")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
     plt.close()
 
-    # Precision-Recall Curve
-    precision, recall, _ = precision_recall_curve(y_test, probs)
-    plt.figure()
-    plt.plot(recall, precision, label='Decision Tree')
-    plt.xlabel('Recall')
-    plt.ylabel('Precision')
-    plt.title('Precision-Recall Curve - Decision Tree')
-    plt.legend()
-    plt.savefig(f"{RESULTS_DIR}/pr_curve.pdf")
-    plt.savefig(f"{RESULTS_DIR}/pr_curve.svg")
-    plt.close()
+    if len(model.classes_) > 1:
+        plot_curves(y_test, probs)
+    return eval_time_ns
 
-print(f"✅ Kết quả và hình ảnh lưu tại: {RESULTS_DIR}")
+
+def plot_curves(y_true: np.ndarray, probs: np.ndarray) -> None:
+    fpr, tpr, _ = roc_curve(y_true, probs)
+    auc_score = roc_auc_score(y_true, probs)
+    precision, recall, _ = precision_recall_curve(y_true, probs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    axes[0].plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
+    axes[0].plot([0, 1], [0, 1], linestyle="--", color="gray")
+    axes[0].set_xlabel("False Positive Rate")
+    axes[0].set_ylabel("True Positive Rate")
+    axes[0].set_title("ROC Curve")
+    axes[0].legend()
+
+    axes[1].plot(recall, precision, label="Decision Tree")
+    axes[1].set_xlabel("Recall")
+    axes[1].set_ylabel("Precision")
+    axes[1].set_title("Precision-Recall Curve")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.pdf")
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.svg")
+    plt.close(fig)
+
+
+def main() -> None:
+    need_train = not os.path.exists(MODEL_SAVE_PATH)
+    need_eval = not os.path.exists(PREDICTIONS_PATH)
+
+    model = None
+    train_time_ns = 0
+
+    if need_train or need_eval:
+        X_train, X_val, X_test, y_train, y_val, y_test, *_ = load_data()
+        X_tr = np.concatenate([X_train, X_val], axis=0)
+        y_tr = np.concatenate([y_train, y_val], axis=0)
+
+    if need_train:
+        model, train_time_ns = train_model(X_tr, y_tr)
+    else:
+        model = joblib.load(MODEL_SAVE_PATH)
+
+    if need_eval:
+        evaluate_model(model, X_test, y_test, train_time_ns)
+    else:
+        data = np.load(PREDICTIONS_PATH)
+        y_test = data["y_test"]
+        probs = data["probs"]
+        if len(np.unique(y_test)) > 1:
+            plot_curves(y_test, probs)
+        print("✅ Model and predictions found; skipped training and evaluation.")
+
+    print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
+    print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/train_RF.py
+++ b/src/training/train_RF.py
@@ -1,83 +1,154 @@
+"""Training and evaluation script for RandomForest classifier.
+
+This script trains the model once and caches both the trained model and
+prediction artifacts. Subsequent executions reuse cached results and only
+regenerate plots when needed.
+"""
+
+import json
 import os
+import time
+
 import joblib
+import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import classification_report, confusion_matrix, ConfusionMatrixDisplay, f1_score
-import matplotlib.pyplot as plt
-import json
+from sklearn.metrics import (
+    ConfusionMatrixDisplay,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_recall_curve,
+    roc_auc_score,
+    roc_curve,
+)
 
-# ====== CONFIG ======
-DATA_PATH = 'data/processed/preprocessed_data_v4.pkl'  # Đổi tên nếu bạn lưu file khác
-MODEL_SAVE_PATH = 'models/models_v4/model_rf.pkl'
-RESULTS_DIR = 'outputs/results_v4/randomforest'
+DATA_PATH = "data/processed/preprocessed_data_v4.pkl"
+MODEL_SAVE_PATH = "models/models_v4/model_rf.pkl"
+RESULTS_DIR = "outputs/results_v4/randomforest"
+PREDICTIONS_PATH = os.path.join(RESULTS_DIR, "predictions.npz")
+REPORT_PATH = os.path.join(RESULTS_DIR, "classification_report.json")
+
 os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
 os.makedirs(RESULTS_DIR, exist_ok=True)
 
-# ====== LOAD DATA ======
-# Giả sử data đã split/scale thành:
-# X_train, X_val, X_test, y_train, y_val, y_test
-X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
+SEED = 42
 
-# Có thể concat X_train và X_val nếu muốn train trên all train data:
-X_tr = np.concatenate([X_train, X_val], axis=0)
-y_tr = np.concatenate([y_train, y_val], axis=0)
 
-# ====== TRAIN RF ======
-rf = RandomForestClassifier(
-    n_estimators=100,
-    max_depth=None,
-    random_state=42,
-    n_jobs=-1
-)
-rf.fit(X_tr, y_tr)
-joblib.dump(rf, MODEL_SAVE_PATH)
+def load_data():
+    """Load train/validation/test splits from disk."""
+    return joblib.load(DATA_PATH)
 
-# ====== EVALUATE RF ======
-preds = rf.predict(X_test)
-probs = rf.predict_proba(X_test)[:, 1]  # Xác suất class 1 (binary)
 
-# Classification report
-report = classification_report(y_test, preds, output_dict=True)
-with open(f"{RESULTS_DIR}/classification_report.json", "w") as f:
-    json.dump(report, f, indent=4)
-print(classification_report(y_test, preds))
-print("F1-micro:", f1_score(y_test, preds, average='micro'))
+def train_model(X_tr: np.ndarray, y_tr: np.ndarray) -> tuple[RandomForestClassifier, int]:
+    """Train RandomForest and return model with training time in ns."""
+    model = RandomForestClassifier(
+        n_estimators=100,
+        max_depth=None,
+        random_state=SEED,
+        n_jobs=-1,
+    )
+    start = time.perf_counter_ns()
+    model.fit(X_tr, y_tr)
+    end = time.perf_counter_ns()
+    joblib.dump(model, MODEL_SAVE_PATH)
+    return model, end - start
 
-# Confusion Matrix (normalized as percentage)
-cm = confusion_matrix(y_test, preds, normalize='true')
-disp = ConfusionMatrixDisplay(confusion_matrix=cm)
-disp.plot(values_format='.2%')
-plt.title("Confusion Matrix - Random Forest")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
-plt.close()
 
-# ROC Curve (nếu bạn muốn)
-from sklearn.metrics import roc_curve, roc_auc_score, precision_recall_curve
+def evaluate_model(
+    model: RandomForestClassifier, X_test: np.ndarray, y_test: np.ndarray, train_time_ns: int
+) -> int:
+    """Evaluate the model, save metrics/predictions and return evaluation time."""
+    start = time.perf_counter_ns()
+    preds = model.predict(X_test)
+    probs = model.predict_proba(X_test)[:, 1]
+    end = time.perf_counter_ns()
+    eval_time_ns = end - start
 
-fpr, tpr, _ = roc_curve(y_test, probs)
-auc_score = roc_auc_score(y_test, probs)
-plt.figure()
-plt.plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
-plt.plot([0, 1], [0, 1], linestyle='--', color='gray')
-plt.xlabel('False Positive Rate')
-plt.ylabel('True Positive Rate')
-plt.title('ROC Curve - Random Forest')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/roc_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/roc_curve.svg")
-plt.close()
+    np.savez(PREDICTIONS_PATH, y_test=y_test, preds=preds, probs=probs)
 
-# Precision-Recall Curve
-precision, recall, _ = precision_recall_curve(y_test, probs)
-plt.figure()
-plt.plot(recall, precision, label='Random Forest')
-plt.xlabel('Recall')
-plt.ylabel('Precision')
-plt.title('Precision-Recall Curve - Random Forest')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/pr_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/pr_curve.svg")
-plt.close()
+    report = classification_report(y_test, preds, output_dict=True)
+    report["timing"] = {
+        "train_time_ns": train_time_ns,
+        "evaluate_time_ns": eval_time_ns,
+    }
+    with open(REPORT_PATH, "w") as f:
+        json.dump(report, f, indent=4)
 
-print(f"✅ Kết quả và hình ảnh lưu tại: {RESULTS_DIR}")
+    print("=== RandomForest Classification Report ===")
+    print(classification_report(y_test, preds))
+    print("F1-micro:", f1_score(y_test, preds, average="micro"))
+    print(f"Train time: {train_time_ns / 1e9:.4f}s  ({train_time_ns} ns)")
+    print(f"Eval time:  {eval_time_ns / 1e9:.4f}s  ({eval_time_ns} ns)")
+
+    cm = confusion_matrix(y_test, preds, normalize="true")
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm)
+    disp.plot(values_format=".2%")
+    plt.title("Confusion Matrix - RandomForest")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
+    plt.close()
+
+    plot_curves(y_test, probs)
+    return eval_time_ns
+
+
+def plot_curves(y_true: np.ndarray, probs: np.ndarray) -> None:
+    """Draw ROC and PR curves into a single figure."""
+    fpr, tpr, _ = roc_curve(y_true, probs)
+    auc_score = roc_auc_score(y_true, probs)
+    precision, recall, _ = precision_recall_curve(y_true, probs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    axes[0].plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
+    axes[0].plot([0, 1], [0, 1], linestyle="--", color="gray")
+    axes[0].set_xlabel("False Positive Rate")
+    axes[0].set_ylabel("True Positive Rate")
+    axes[0].set_title("ROC Curve")
+    axes[0].legend()
+
+    axes[1].plot(recall, precision, label="RandomForest")
+    axes[1].set_xlabel("Recall")
+    axes[1].set_ylabel("Precision")
+    axes[1].set_title("Precision-Recall Curve")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.pdf")
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.svg")
+    plt.close(fig)
+
+
+def main() -> None:
+    need_train = not os.path.exists(MODEL_SAVE_PATH)
+    need_eval = not os.path.exists(PREDICTIONS_PATH)
+
+    model = None
+    train_time_ns = 0
+
+    if need_train or need_eval:
+        X_train, X_val, X_test, y_train, y_val, y_test, *_ = load_data()
+        X_tr = np.concatenate([X_train, X_val], axis=0)
+        y_tr = np.concatenate([y_train, y_val], axis=0)
+
+    if need_train:
+        model, train_time_ns = train_model(X_tr, y_tr)
+    else:
+        model = joblib.load(MODEL_SAVE_PATH)
+
+    if need_eval:
+        evaluate_model(model, X_test, y_test, train_time_ns)
+    else:
+        data = np.load(PREDICTIONS_PATH)
+        y_test = data["y_test"]
+        probs = data["probs"]
+        plot_curves(y_test, probs)
+        print("✅ Model and predictions found; skipped training and evaluation.")
+
+    print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
+    print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/train_RF_v3.py
+++ b/src/training/train_RF_v3.py
@@ -1,97 +1,153 @@
+"""Training and evaluation script for RandomForest on v3 dataset with label remapping."""
+
+import json
 import os
+import time
+
 import joblib
+import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import classification_report, confusion_matrix, ConfusionMatrixDisplay, f1_score
-import matplotlib.pyplot as plt
-import json
-from sklearn.metrics import roc_curve, roc_auc_score, precision_recall_curve
-# ====== CONFIG ======
-DATA_PATH = 'data/processed/preprocessed_data_v3.pkl'  # Đổi tên nếu bạn lưu file khác
-MODEL_SAVE_PATH = 'models/models_v3/model_rf.pkl'
-RESULTS_DIR = 'outputs/results_v3/randomforest'
+from sklearn.metrics import (
+    ConfusionMatrixDisplay,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_recall_curve,
+    roc_auc_score,
+    roc_curve,
+)
+
+DATA_PATH = "data/processed/preprocessed_data_v3.pkl"
+MODEL_SAVE_PATH = "models/models_v3/model_rf.pkl"
+RESULTS_DIR = "outputs/results_v3/randomforest"
+PREDICTIONS_PATH = os.path.join(RESULTS_DIR, "predictions.npz")
+REPORT_PATH = os.path.join(RESULTS_DIR, "classification_report.json")
+
 os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
 os.makedirs(RESULTS_DIR, exist_ok=True)
 
-# ====== LOAD DATA ======
-# Giả sử data đã split/scale thành:
-# X_train, X_val, X_test, y_train, y_val, y_test
-X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
-
-# Có thể concat X_train và X_val nếu muốn train trên all train data:
-X_tr = np.concatenate([X_train, X_val], axis=0)
-y_tr = np.concatenate([y_train, y_val], axis=0)
-
-# ====== TRAIN RF ======
-rf = RandomForestClassifier(
-    n_estimators=100,
-    max_depth=None,
-    random_state=42,
-    n_jobs=-1
-)
-rf.fit(X_tr, y_tr)
-joblib.dump(rf, MODEL_SAVE_PATH)
-
-# ====== EVALUATE RF ======
-#
-#  The model was trained with:       0 = MITM attack, 1 = normal
-#  All your other experiments use:   0 = normal,     1 = MITM attack
-#  We therefore flip labels **once** right here.
-
-# ────────────────────────────────────────────────────────────────────────
-# 🔄 REMAP LABELS FOR EVALUATION
-# ────────────────────────────────────────────────────────────────────────
-# 1) Ground truth
-y_test_fixed = 1 - y_test            # 0↔1
-
-# 2) Probabilities for the “attack” class
-#    rf.predict_proba returns columns in the order rf.classes_
-idx_attack   = list(rf.classes_).index(0)   # column that was ‘0’ during training
-probs_fixed  = rf.predict_proba(X_test)[:, idx_attack]
-
-# 3) Binary predictions after the remap
-preds_fixed  = (probs_fixed >= 0.5).astype(int)
-# ────────────────────────────────────────────────────────────────────────
-
-# --- Standard reports/plots but using *_fixed ---
-report = classification_report(y_test_fixed, preds_fixed, output_dict=True)
-with open(f"{RESULTS_DIR}/classification_report.json", "w") as f:
-    json.dump(report, f, indent=4)
-print(classification_report(y_test_fixed, preds_fixed))
-print("F1‑micro:", f1_score(y_test_fixed, preds_fixed, average='micro'))
-
-cm = confusion_matrix(y_test_fixed, preds_fixed, normalize='true')
-ConfusionMatrixDisplay(cm).plot(values_format='.2%')
-plt.title("Confusion Matrix – Random Forest (labels fixed)")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
-plt.close()
+SEED = 42
 
 
-
-fpr, tpr, _   = roc_curve(y_test_fixed, probs_fixed)
-auc_score     = roc_auc_score(y_test_fixed, probs_fixed)
-plt.figure()
-plt.plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
-plt.plot([0, 1], [0, 1], '--', color='gray')
-plt.xlabel('False Positive Rate'); plt.ylabel('True Positive Rate')
-plt.title('ROC Curve – Random Forest (labels fixed)')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/roc_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/roc_curve.svg")
-plt.close()
-
-precision, recall, _ = precision_recall_curve(y_test_fixed, probs_fixed)
-plt.figure()
-plt.plot(recall, precision, label='Random Forest')
-plt.xlabel('Recall'); plt.ylabel('Precision')
-plt.title('PR Curve – Random Forest (labels fixed)')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/pr_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/pr_curve.svg")
-plt.close()
-
-print(f"✅ Kết quả đã hiệu chỉnh nhãn được lưu tại: {RESULTS_DIR}")
+def load_data():
+    return joblib.load(DATA_PATH)
 
 
-print(f"✅ Kết quả và hình ảnh lưu tại: {RESULTS_DIR}")
+def train_model(X_tr: np.ndarray, y_tr: np.ndarray) -> tuple[RandomForestClassifier, int]:
+    model = RandomForestClassifier(
+        n_estimators=100,
+        max_depth=None,
+        random_state=SEED,
+        n_jobs=-1,
+    )
+    start = time.perf_counter_ns()
+    model.fit(X_tr, y_tr)
+    end = time.perf_counter_ns()
+    joblib.dump(model, MODEL_SAVE_PATH)
+    return model, end - start
+
+
+def remap_labels(
+    model: RandomForestClassifier, X_test: np.ndarray, y_test: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    y_test_fixed = 1 - y_test
+    idx_attack = list(model.classes_).index(0)
+    probs_fixed = model.predict_proba(X_test)[:, idx_attack]
+    preds_fixed = (probs_fixed >= 0.5).astype(int)
+    return y_test_fixed, preds_fixed, probs_fixed
+
+
+def evaluate_model(
+    model: RandomForestClassifier, X_test: np.ndarray, y_test: np.ndarray, train_time_ns: int
+) -> int:
+    start = time.perf_counter_ns()
+    y_test_fixed, preds_fixed, probs_fixed = remap_labels(model, X_test, y_test)
+    end = time.perf_counter_ns()
+    eval_time_ns = end - start
+
+    np.savez(PREDICTIONS_PATH, y_test=y_test_fixed, preds=preds_fixed, probs=probs_fixed)
+
+    report = classification_report(y_test_fixed, preds_fixed, output_dict=True)
+    report["timing"] = {
+        "train_time_ns": train_time_ns,
+        "evaluate_time_ns": eval_time_ns,
+    }
+    with open(REPORT_PATH, "w") as f:
+        json.dump(report, f, indent=4)
+
+    print("=== RandomForest v3 Classification Report ===")
+    print(classification_report(y_test_fixed, preds_fixed))
+    print("F1-micro:", f1_score(y_test_fixed, preds_fixed, average="micro"))
+    print(f"Train time: {train_time_ns / 1e9:.4f}s  ({train_time_ns} ns)")
+    print(f"Eval time:  {eval_time_ns / 1e9:.4f}s  ({eval_time_ns} ns)")
+
+    cm = confusion_matrix(y_test_fixed, preds_fixed, normalize="true")
+    ConfusionMatrixDisplay(cm).plot(values_format=".2%")
+    plt.title("Confusion Matrix – RandomForest (labels fixed)")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
+    plt.close()
+
+    plot_curves(y_test_fixed, probs_fixed)
+    return eval_time_ns
+
+
+def plot_curves(y_true: np.ndarray, probs: np.ndarray) -> None:
+    fpr, tpr, _ = roc_curve(y_true, probs)
+    auc_score = roc_auc_score(y_true, probs)
+    precision, recall, _ = precision_recall_curve(y_true, probs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    axes[0].plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
+    axes[0].plot([0, 1], [0, 1], '--', color='gray')
+    axes[0].set_xlabel("False Positive Rate")
+    axes[0].set_ylabel("True Positive Rate")
+    axes[0].set_title("ROC Curve")
+    axes[0].legend()
+
+    axes[1].plot(recall, precision, label="RandomForest")
+    axes[1].set_xlabel("Recall")
+    axes[1].set_ylabel("Precision")
+    axes[1].set_title("Precision-Recall Curve")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.pdf")
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.svg")
+    plt.close(fig)
+
+
+def main() -> None:
+    need_train = not os.path.exists(MODEL_SAVE_PATH)
+    need_eval = not os.path.exists(PREDICTIONS_PATH)
+
+    model = None
+    train_time_ns = 0
+
+    if need_train or need_eval:
+        X_train, X_val, X_test, y_train, y_val, y_test, *_ = load_data()
+        X_tr = np.concatenate([X_train, X_val], axis=0)
+        y_tr = np.concatenate([y_train, y_val], axis=0)
+
+    if need_train:
+        model, train_time_ns = train_model(X_tr, y_tr)
+    else:
+        model = joblib.load(MODEL_SAVE_PATH)
+
+    if need_eval:
+        evaluate_model(model, X_test, y_test, train_time_ns)
+    else:
+        data = np.load(PREDICTIONS_PATH)
+        y_test_fixed = data["y_test"]
+        probs_fixed = data["probs"]
+        plot_curves(y_test_fixed, probs_fixed)
+        print("✅ Model and predictions found; skipped training and evaluation.")
+
+    print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
+    print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/train_XGBoost.py
+++ b/src/training/train_XGBoost.py
@@ -1,84 +1,154 @@
-import os
-import joblib
-import numpy as np
-import json
-from xgboost import XGBClassifier
-from sklearn.metrics import classification_report, confusion_matrix, ConfusionMatrixDisplay, f1_score, roc_curve, roc_auc_score, precision_recall_curve
-import matplotlib.pyplot as plt
+"""Training and evaluation script for XGBoost classifier with caching.
 
-# ====== CONFIG ======
-DATA_PATH = 'data/processed/preprocessed_data_v4.pkl'  
-MODEL_SAVE_PATH = 'models/models_v4/model_xgb.json'
-RESULTS_DIR = 'outputs/results_v4/xgboost'
+The model, predictions, and evaluation metrics are saved to disk so
+subsequent runs skip retraining and evaluation when artifacts exist.
+"""
+
+import json
+import os
+import time
+
+import joblib
+import matplotlib.pyplot as plt
+import numpy as np
+from xgboost import XGBClassifier
+from sklearn.metrics import (
+    ConfusionMatrixDisplay,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_recall_curve,
+    roc_auc_score,
+    roc_curve,
+)
+
+DATA_PATH = "data/processed/preprocessed_data_v4.pkl"
+MODEL_SAVE_PATH = "models/models_v4/model_xgb.json"
+RESULTS_DIR = "outputs/results_v4/xgboost"
+PREDICTIONS_PATH = os.path.join(RESULTS_DIR, "predictions.npz")
+REPORT_PATH = os.path.join(RESULTS_DIR, "classification_report.json")
+
 os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
 os.makedirs(RESULTS_DIR, exist_ok=True)
 
-# ====== LOAD DATA ======
-X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
-# Có thể concat train + val cho train XGB tốt hơn:
-X_tr = np.concatenate([X_train, X_val], axis=0)
-y_tr = np.concatenate([y_train, y_val], axis=0)
+SEED = 42
 
-# ====== TRAIN XGBoost ======
-xgb = XGBClassifier(
-    n_estimators=200,
-    learning_rate=0.05,
-    max_depth=6,
-    subsample=0.8,
-    colsample_bytree=0.8,
-    use_label_encoder=False,
-    eval_metric='logloss',
-    random_state=42,
-    n_jobs=-1,
-    verbosity=1
-)
-xgb.fit(X_tr, y_tr)
-xgb.save_model(MODEL_SAVE_PATH)
 
-# ====== EVALUATE XGBoost ======
-preds = xgb.predict(X_test)
-probs = xgb.predict_proba(X_test)[:, 1]  # Xác suất class 1
+def load_data():
+    return joblib.load(DATA_PATH)
 
-# Classification report
-report = classification_report(y_test, preds, output_dict=True)
-with open(f"{RESULTS_DIR}/classification_report.json", "w") as f:
-    json.dump(report, f, indent=4)
-print(classification_report(y_test, preds))
-print("F1-micro:", f1_score(y_test, preds, average='micro'))
 
-# Confusion Matrix (normalized as percentage)
-cm = confusion_matrix(y_test, preds, normalize='true')
-disp = ConfusionMatrixDisplay(confusion_matrix=cm)
-disp.plot(values_format='.2%')
-plt.title("Confusion Matrix - XGBoost")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
-plt.close()
+def train_model(X_tr: np.ndarray, y_tr: np.ndarray) -> tuple[XGBClassifier, int]:
+    model = XGBClassifier(
+        n_estimators=200,
+        learning_rate=0.05,
+        max_depth=6,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        use_label_encoder=False,
+        eval_metric="logloss",
+        random_state=SEED,
+        n_jobs=-1,
+        verbosity=1,
+    )
+    start = time.perf_counter_ns()
+    model.fit(X_tr, y_tr)
+    end = time.perf_counter_ns()
+    model.save_model(MODEL_SAVE_PATH)
+    return model, end - start
 
-# ROC Curve
-fpr, tpr, _ = roc_curve(y_test, probs)
-auc_score = roc_auc_score(y_test, probs)
-plt.figure()
-plt.plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
-plt.plot([0, 1], [0, 1], linestyle='--', color='gray')
-plt.xlabel('False Positive Rate')
-plt.ylabel('True Positive Rate')
-plt.title('ROC Curve - XGBoost')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/roc_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/roc_curve.svg")
-plt.close()
 
-# Precision-Recall Curve
-precision, recall, _ = precision_recall_curve(y_test, probs)
-plt.figure()
-plt.plot(recall, precision, label='XGBoost')
-plt.xlabel('Recall')
-plt.ylabel('Precision')
-plt.title('Precision-Recall Curve - XGBoost')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/pr_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/pr_curve.svg")
-plt.close()
+def evaluate_model(model: XGBClassifier, X_test: np.ndarray, y_test: np.ndarray, train_time_ns: int) -> int:
+    start = time.perf_counter_ns()
+    preds = model.predict(X_test)
+    probs = model.predict_proba(X_test)[:, 1]
+    end = time.perf_counter_ns()
+    eval_time_ns = end - start
 
-print(f"✅ Kết quả và hình ảnh lưu tại: {RESULTS_DIR}")
+    np.savez(PREDICTIONS_PATH, y_test=y_test, preds=preds, probs=probs)
+
+    report = classification_report(y_test, preds, output_dict=True)
+    report["timing"] = {
+        "train_time_ns": train_time_ns,
+        "evaluate_time_ns": eval_time_ns,
+    }
+    with open(REPORT_PATH, "w") as f:
+        json.dump(report, f, indent=4)
+
+    print("=== XGBoost Classification Report ===")
+    print(classification_report(y_test, preds))
+    print("F1-micro:", f1_score(y_test, preds, average="micro"))
+    print(f"Train time: {train_time_ns / 1e9:.4f}s  ({train_time_ns} ns)")
+    print(f"Eval time:  {eval_time_ns / 1e9:.4f}s  ({eval_time_ns} ns)")
+
+    cm = confusion_matrix(y_test, preds, normalize="true")
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm)
+    disp.plot(values_format=".2%")
+    plt.title("Confusion Matrix - XGBoost")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
+    plt.close()
+
+    plot_curves(y_test, probs)
+    return eval_time_ns
+
+
+def plot_curves(y_true: np.ndarray, probs: np.ndarray) -> None:
+    fpr, tpr, _ = roc_curve(y_true, probs)
+    auc_score = roc_auc_score(y_true, probs)
+    precision, recall, _ = precision_recall_curve(y_true, probs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    axes[0].plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
+    axes[0].plot([0, 1], [0, 1], linestyle="--", color="gray")
+    axes[0].set_xlabel("False Positive Rate")
+    axes[0].set_ylabel("True Positive Rate")
+    axes[0].set_title("ROC Curve")
+    axes[0].legend()
+
+    axes[1].plot(recall, precision, label="XGBoost")
+    axes[1].set_xlabel("Recall")
+    axes[1].set_ylabel("Precision")
+    axes[1].set_title("Precision-Recall Curve")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.pdf")
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.svg")
+    plt.close(fig)
+
+
+def main() -> None:
+    need_train = not os.path.exists(MODEL_SAVE_PATH)
+    need_eval = not os.path.exists(PREDICTIONS_PATH)
+
+    model = None
+    train_time_ns = 0
+
+    if need_train or need_eval:
+        X_train, X_val, X_test, y_train, y_val, y_test, *_ = load_data()
+        X_tr = np.concatenate([X_train, X_val], axis=0)
+        y_tr = np.concatenate([y_train, y_val], axis=0)
+
+    if need_train:
+        model, train_time_ns = train_model(X_tr, y_tr)
+    else:
+        model = XGBClassifier()
+        model.load_model(MODEL_SAVE_PATH)
+
+    if need_eval:
+        evaluate_model(model, X_test, y_test, train_time_ns)
+    else:
+        data = np.load(PREDICTIONS_PATH)
+        y_test = data["y_test"]
+        probs = data["probs"]
+        plot_curves(y_test, probs)
+        print("✅ Model and predictions found; skipped training and evaluation.")
+
+    print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
+    print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/train_boosting_RF.py
+++ b/src/training/train_boosting_RF.py
@@ -1,137 +1,174 @@
-import os
-import json
-import joblib
-import numpy as np
-import matplotlib.pyplot as plt
-import time
-from xgboost import XGBRFClassifier  # XGBoost's Random-Forest variant
+"""Training and evaluation script for XGBRF classifier.
 
+This script trains the model once and caches both the trained model and
+evaluation results. Subsequent executions will reuse the cached artifacts and
+only regenerate plots, avoiding repeated expensive computations.
+
+Saved artifacts:
+    - Model: ``MODEL_SAVE_PATH``
+    - Predictions & probabilities: ``PREDICTIONS_PATH``
+    - Classification report with timing: ``REPORT_PATH``
+    - Confusion matrix and combined ROC/PR curves in ``RESULTS_DIR``
+"""
+
+import json
+import os
+import time
+
+import joblib
+import matplotlib.pyplot as plt
+import numpy as np
 from sklearn.metrics import (
+    ConfusionMatrixDisplay,
     classification_report,
     confusion_matrix,
-    ConfusionMatrixDisplay,
     f1_score,
-    roc_curve,
+    precision_recall_curve,
     roc_auc_score,
-    precision_recall_curve
+    roc_curve,
 )
+from xgboost import XGBRFClassifier
 
 # ================================
 # CONFIG
 # ================================
-DATA_PATH        = 'data/processed/preprocessed_data_v4.pkl'
-MODEL_SAVE_PATH  = 'models/models_v4/model_xgbrf.pkl'
-RESULTS_DIR      = 'outputs/results_v4/xgbrf'
+DATA_PATH = "data/processed/preprocessed_data_v4.pkl"
+MODEL_SAVE_PATH = "models/models_v4/model_xgbrf.pkl"
+RESULTS_DIR = "outputs/results_v4/xgbrf"
+PREDICTIONS_PATH = os.path.join(RESULTS_DIR, "predictions.npz")
+REPORT_PATH = os.path.join(RESULTS_DIR, "classification_report.json")
 
 os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
 os.makedirs(RESULTS_DIR, exist_ok=True)
 
 SEED = 42
 
-# ================================
-# LOAD DATA
-# Assumes joblib contains:
-# X_train, X_val, X_test, y_train, y_val, y_test, ...
-# ================================
-X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
 
-# Train on train + val (your previous pattern)
-X_tr = np.concatenate([X_train, X_val], axis=0)
-y_tr = np.concatenate([y_train, y_val], axis=0)
+def load_data():
+    """Load train/validation/test splits from disk."""
+    return joblib.load(DATA_PATH)
 
-# ================================
-# TRAIN: XGBoost Random Forest
-# Notes:
-# - XGBRFClassifier builds trees *without boosting* (RF-style).
-# - Use subsample < 1 and colsample_bynode < 1 for RF behavior.
-# - tree_method='hist' is fast on CPU; switch to 'gpu_hist' if you have GPU.
-# ================================
-xgbrf = XGBRFClassifier(
-    n_estimators=500,        # more trees, like RF
-    max_depth=6,
-    subsample=0.8,           # RF-style row subsampling
-    colsample_bynode=0.8,    # RF-style feature subsampling per split
-    reg_lambda=1.0,
-    min_child_weight=1.0,
-    eval_metric='logloss',
-    tree_method='hist',
-    n_jobs=-1,
-    random_state=SEED
-)
 
-# ===== TRAINING TIME =====
-start_train = time.perf_counter_ns()
-xgbrf.fit(X_tr, y_tr)
-end_train = time.perf_counter_ns()
+def train_model(X_tr: np.ndarray, y_tr: np.ndarray) -> tuple[XGBRFClassifier, int]:
+    """Train the XGBRFClassifier and return it with training time in ns."""
+    model = XGBRFClassifier(
+        n_estimators=500,
+        max_depth=6,
+        subsample=0.8,
+        colsample_bynode=0.8,
+        reg_lambda=1.0,
+        min_child_weight=1.0,
+        eval_metric="logloss",
+        tree_method="hist",
+        n_jobs=-1,
+        random_state=SEED,
+    )
 
-# Store both ns and seconds for clarity
-train_time_ns = end_train - start_train
+    start = time.perf_counter_ns()
+    model.fit(X_tr, y_tr)
+    end = time.perf_counter_ns()
 
-joblib.dump(xgbrf, MODEL_SAVE_PATH)
+    joblib.dump(model, MODEL_SAVE_PATH)
+    return model, end - start
 
-# ================================
-# EVALUATE
-# ================================
-start_evaluate = time.perf_counter_ns()
-preds = xgbrf.predict(X_test)
-probs = xgbrf.predict_proba(X_test)[:, 1]  # probability of class 1 (binary)
-end_evaluate = time.perf_counter_ns()
 
-# Fix: evaluation duration should be end - start
-evaluate_time_ns = end_evaluate - start_evaluate
-time_per_sample = evaluate_time_ns / len(X_test)
-# Classification report (+ timing info)
-report = classification_report(y_test, preds, output_dict=True)
+def evaluate_model(
+    model: XGBRFClassifier, X_test: np.ndarray, y_test: np.ndarray, train_time_ns: int
+) -> int:
+    """Evaluate the model, save metrics/predictions and return evaluation time."""
+    start = time.perf_counter_ns()
+    preds = model.predict(X_test)
+    probs = model.predict_proba(X_test)[:, 1]
+    end = time.perf_counter_ns()
+    eval_time_ns = end - start
 
-# Add timing metadata into the same JSON file
-report["timing"] = {
-    "train_time_ns": train_time_ns,
-    "evaluate_time_ns": evaluate_time_ns
-}
+    # Persist predictions to enable future plotting without re-evaluation
+    np.savez(PREDICTIONS_PATH, y_test=y_test, preds=preds, probs=probs)
 
-with open(f"{RESULTS_DIR}/classification_report.json", "w") as f:
-    json.dump(report, f, indent=4)
+    report = classification_report(y_test, preds, output_dict=True)
+    report["timing"] = {
+        "train_time_ns": train_time_ns,
+        "evaluate_time_ns": eval_time_ns,
+    }
 
-print("=== XGBRF Classification Report ===")
-print(classification_report(y_test, preds))
-print("F1-micro:", f1_score(y_test, preds, average='micro'))
-print(f"Train time: {train_time_s:.4f}s  ({train_time_ns} ns)")
-print(f"Eval time:  {evaluate_time_s:.4f}s  ({evaluate_time_ns} ns)")
+    with open(REPORT_PATH, "w") as f:
+        json.dump(report, f, indent=4)
 
-# Confusion Matrix (normalized as percentage)
-cm = confusion_matrix(y_test, preds, normalize='true')
-disp = ConfusionMatrixDisplay(confusion_matrix=cm)
-disp.plot(values_format='.2%')
-plt.title("Confusion Matrix - XGBRF")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
-plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
-plt.close()
+    print("=== XGBRF Classification Report ===")
+    print(classification_report(y_test, preds))
+    print("F1-micro:", f1_score(y_test, preds, average="micro"))
+    print(f"Train time: {train_time_ns / 1e9:.4f}s  ({train_time_ns} ns)")
+    print(f"Eval time:  {eval_time_ns / 1e9:.4f}s  ({eval_time_ns} ns)")
 
-# ROC Curve
-fpr, tpr, _ = roc_curve(y_test, probs)
-auc_score = roc_auc_score(y_test, probs)
-plt.figure()
-plt.plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
-plt.plot([0, 1], [0, 1], linestyle='--', color='gray')
-plt.xlabel('False Positive Rate')
-plt.ylabel('True Positive Rate')
-plt.title('ROC Curve - XGBRF')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/roc_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/roc_curve.svg")
-plt.close()
+    cm = confusion_matrix(y_test, preds, normalize="true")
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm)
+    disp.plot(values_format=".2%")
+    plt.title("Confusion Matrix - XGBRF")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.pdf")
+    plt.savefig(f"{RESULTS_DIR}/confusion_matrix.svg")
+    plt.close()
 
-# Precision-Recall Curve
-precision, recall, _ = precision_recall_curve(y_test, probs)
-plt.figure()
-plt.plot(recall, precision, label='XGBRF')
-plt.xlabel('Recall')
-plt.ylabel('Precision')
-plt.title('Precision-Recall Curve - XGBRF')
-plt.legend()
-plt.savefig(f"{RESULTS_DIR}/pr_curve.pdf")
-plt.savefig(f"{RESULTS_DIR}/pr_curve.svg")
-plt.close()
+    plot_curves(y_test, probs)
+    return eval_time_ns
 
-print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
-print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+def plot_curves(y_true: np.ndarray, probs: np.ndarray) -> None:
+    """Draw ROC and PR curves into a single figure."""
+    fpr, tpr, _ = roc_curve(y_true, probs)
+    auc_score = roc_auc_score(y_true, probs)
+    precision, recall, _ = precision_recall_curve(y_true, probs)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    axes[0].plot(fpr, tpr, label=f"AUC = {auc_score:.2f}")
+    axes[0].plot([0, 1], [0, 1], linestyle="--", color="gray")
+    axes[0].set_xlabel("False Positive Rate")
+    axes[0].set_ylabel("True Positive Rate")
+    axes[0].set_title("ROC Curve")
+    axes[0].legend()
+
+    axes[1].plot(recall, precision, label="XGBRF")
+    axes[1].set_xlabel("Recall")
+    axes[1].set_ylabel("Precision")
+    axes[1].set_title("Precision-Recall Curve")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.pdf")
+    fig.savefig(f"{RESULTS_DIR}/roc_pr_curves.svg")
+    plt.close(fig)
+
+
+def main() -> None:
+    need_train = not os.path.exists(MODEL_SAVE_PATH)
+    need_eval = not os.path.exists(PREDICTIONS_PATH)
+
+    model = None
+    train_time_ns = 0
+
+    if need_train or need_eval:
+        X_train, X_val, X_test, y_train, y_val, y_test, *_ = load_data()
+        X_tr = np.concatenate([X_train, X_val], axis=0)
+        y_tr = np.concatenate([y_train, y_val], axis=0)
+
+    if need_train:
+        model, train_time_ns = train_model(X_tr, y_tr)
+    else:
+        model = joblib.load(MODEL_SAVE_PATH)
+
+    if need_eval:
+        evaluate_model(model, X_test, y_test, train_time_ns)
+    else:
+        data = np.load(PREDICTIONS_PATH)
+        y_test = data["y_test"]
+        probs = data["probs"]
+        plot_curves(y_test, probs)
+        print("✅ Model and predictions found; skipped training and evaluation.")
+
+    print(f"✅ Model saved to: {MODEL_SAVE_PATH}")
+    print(f"✅ Results & plots saved in: {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add caching and timing to Random Forest, Decision Tree, XGBoost and RF v3 trainers
- persist predictions and reports to skip reevaluation and merge ROC/PR plots

## Testing
- `python -m py_compile src/training/*.py`


------
https://chatgpt.com/codex/tasks/task_b_689d9dd2b6f4832cb5312c8f2be40284