### PR TITLE
refactor: centralize dataset and seeding utilities

### DIFF
--- a/src/inference/generate_predictions.py
+++ b/src/inference/generate_predictions.py
@@ -1,5 +1,6 @@
 # Script to generate prediction files for all models without retraining
 import os
+
 import joblib
 import numpy as np
 import torch
@@ -9,22 +10,14 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.tree import DecisionTreeClassifier
 from xgboost import XGBClassifier
 
+from ..training.utils import TabularSequenceDataset
+
 PRED_DIR = 'predictions'
 os.makedirs(PRED_DIR, exist_ok=True)
 
 # =====================
 # Utility functions
 # =====================
-class TabularSequenceDataset(Dataset):
-    def __init__(self, X, y):
-        X_arr = X.values if hasattr(X, 'values') else X
-        self.X = torch.tensor(X_arr, dtype=torch.float32)
-        self.y = torch.tensor(y.values if hasattr(y, 'values') else y, dtype=torch.long)
-    def __len__(self):
-        return len(self.X)
-    def __getitem__(self, idx):
-        return {'inputs': self.X[idx].unsqueeze(-1), 'labels': self.y[idx]}
-
 class TabularDataset(Dataset):
     def __init__(self, X, y):
         X_arr = X.values if hasattr(X, 'values') else X

--- a/src/training/train_BiLSTM.py
+++ b/src/training/train_BiLSTM.py
@@ -1,6 +1,7 @@
 # src/training/train_BiLSTM.py
 import os, json, time, numpy as np, joblib, torch, torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader
+from .utils import TabularSequenceDataset, set_seed
 
 # ---------- Config ----------
 RUN_ID      = "v4"
@@ -17,24 +18,6 @@ SEED        = 42
 DEVICE      = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 os.makedirs(MODEL_DIR, exist_ok=True)
-
-def set_seed(s=42):
-    import random
-    random.seed(s); np.random.seed(s); torch.manual_seed(s)
-    if torch.cuda.is_available(): torch.cuda.manual_seed_all(s)
-
-# ---------- Dataset ----------
-class TabularSequenceDataset(Dataset):
-    """
-    Treat each feature vector as a length-T sequence with input_size=1:
-      X[i] -> (seq_len=T, 1)
-    """
-    def __init__(self, X, y):
-        self.X = torch.tensor(X, dtype=torch.float32)
-        self.y = torch.tensor(y.values if hasattr(y, "values") else y, dtype=torch.long)
-    def __len__(self): return len(self.X)
-    def __getitem__(self, idx):
-        return {"inputs": self.X[idx].unsqueeze(-1), "labels": self.y[idx]}
 
 # ---------- Model ----------
 class TabularBiLSTM(nn.Module):

--- a/src/training/train_LSTM.py
+++ b/src/training/train_LSTM.py
@@ -1,6 +1,7 @@
 # src/training/train_LSTM.py
 import os, json, time, joblib, numpy as np, torch, torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader
+from .utils import TabularSequenceDataset, set_seed
 
 # ---------- Config ----------
 RUN_ID      = "v4"
@@ -24,24 +25,6 @@ DROPOUT     = 0.2
 NUM_CLASSES = 2
 
 os.makedirs(MODEL_DIR, exist_ok=True)
-
-def set_seed(s=42):
-    import random
-    random.seed(s); np.random.seed(s); torch.manual_seed(s)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(s)
-
-# Dataset: turns each row into a sequence of length = n_features and channel=1
-class TabularSequenceDataset(Dataset):
-    def __init__(self, X, y):
-        X_arr = X.values if hasattr(X, "values") else X
-        self.X = torch.tensor(X_arr, dtype=torch.float32)      # (N, seq_len)
-        y_arr = y.values if hasattr(y, "values") else y
-        self.y = torch.tensor(y_arr, dtype=torch.long)
-    def __len__(self): return len(self.X)
-    def __getitem__(self, i):
-        # (seq_len,) -> (seq_len, 1)
-        return {"inputs": self.X[i].unsqueeze(-1), "labels": self.y[i]}
 
 class TabularLSTM(nn.Module):
     def __init__(self, input_size=1, hidden_size=64, num_layers=2, num_classes=2, dropout=0.2):

--- a/src/training/train_bagging_LSTM.py
+++ b/src/training/train_bagging_LSTM.py
@@ -1,8 +1,9 @@
 # src/training/train_bagging_LSTM.py
 import os, json, time, numpy as np, joblib, torch, torch.nn as nn
-from torch.utils.data import Dataset, DataLoader, Subset
+from torch.utils.data import DataLoader, Subset
 from sklearn.utils import resample
 from xgboost import XGBClassifier
+from .utils import TabularSequenceDataset, set_seed
 
 # ---------- Config ----------
 RUN_ID      = "v4"
@@ -24,24 +25,10 @@ EPOCHS      = 20
 PATIENCE    = 5
 LR          = 1e-3
 SEED        = 42
-
-np.random.seed(SEED)
-torch.manual_seed(SEED)
-if torch.cuda.is_available():
-    torch.cuda.manual_seed_all(SEED)
+set_seed(SEED)
 
 # ---------- Data ----------
 X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
-
-class TabularSequenceDataset(Dataset):
-    def __init__(self, X, y):
-        X_arr = X.values if hasattr(X, "values") else X
-        y_arr = y.values if hasattr(y, "values") else y
-        self.X = torch.tensor(X_arr, dtype=torch.float32)
-        self.y = torch.tensor(y_arr, dtype=torch.long)
-    def __len__(self): return len(self.X)
-    def __getitem__(self, idx):
-        return {"inputs": self.X[idx].unsqueeze(-1), "labels": self.y[idx]}
 
 full_train_ds = TabularSequenceDataset(X_train, y_train)
 val_ds        = TabularSequenceDataset(X_val,   y_val)

--- a/src/training/train_xgboost_lstm.py
+++ b/src/training/train_xgboost_lstm.py
@@ -1,7 +1,8 @@
 # src/training/train_xgboost_lstm.py
 import os, json, time, joblib, numpy as np, torch, torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader
 from xgboost import XGBClassifier
+from .utils import TabularSequenceDataset, set_seed
 
 # ---------- Config ----------
 RUN_ID          = "v4"
@@ -20,22 +21,10 @@ EPOCHS     = 30
 PATIENCE   = 8
 LR         = 1e-3
 SEED       = 42
-
-np.random.seed(SEED)
-torch.manual_seed(SEED)
-if torch.cuda.is_available():
-    torch.cuda.manual_seed_all(SEED)
+set_seed(SEED)
 
 # ---------- Data ----------
 X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load(DATA_PATH)
-
-class TabularSequenceDataset(Dataset):
-    def __init__(self, X, y):
-        self.X = torch.tensor(X, dtype=torch.float32)
-        self.y = torch.tensor(y.values if hasattr(y, "values") else y, dtype=torch.long)
-    def __len__(self): return len(self.X)
-    def __getitem__(self, idx):
-        return {"inputs": self.X[idx].unsqueeze(-1), "labels": self.y[idx]}
 
 train_loader = DataLoader(TabularSequenceDataset(X_train, y_train),
                           batch_size=BATCH_SIZE, shuffle=True)

--- a/src/training/utils.py
+++ b/src/training/utils.py
@@ -1,0 +1,29 @@
+import random
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+def set_seed(s: int = 42) -> None:
+    """Set random seed for Python, NumPy, and torch."""
+    random.seed(s)
+    np.random.seed(s)
+    torch.manual_seed(s)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(s)
+
+
+class TabularSequenceDataset(Dataset):
+    """Wrap tabular features so each row becomes a 1D sequence."""
+
+    def __init__(self, X, y):
+        X_arr = X.values if hasattr(X, "values") else X
+        self.X = torch.tensor(X_arr, dtype=torch.float32)
+        y_arr = y.values if hasattr(y, "values") else y
+        self.y = torch.tensor(y_arr, dtype=torch.long)
+
+    def __len__(self) -> int:
+        return len(self.X)
+
+    def __getitem__(self, idx):
+        return {"inputs": self.X[idx].unsqueeze(-1), "labels": self.y[idx]}


### PR DESCRIPTION
## Summary
- add shared `TabularSequenceDataset` and `set_seed` helpers
- refactor LSTM-related training scripts to use new utilities
- reuse shared `TabularSequenceDataset` in prediction generator
- switch training and inference scripts to relative imports for shared utilities

## Testing
- `python -m py_compile src/training/utils.py src/training/train_LSTM.py src/training/train_BiLSTM.py src/training/train_bagging_LSTM.py src/training/train_xgboost_lstm.py src/inference/generate_predictions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6e8f4d4fc832ca5a91165072de495