### PR TITLE
Align XGBoost model filename across components

### DIFF
--- a/src/eval/eval_all.py
+++ b/src/eval/eval_all.py
@@ -326,7 +326,7 @@ def eval_sklearn_like(model_key, model_path, use_flat=False):
 
 def eval_rf():     eval_sklearn_like("Random Forest",     os.path.join(MODELS_DIR, "rf.pkl"),     use_flat=False)
 def eval_dt():     eval_sklearn_like("Decision Tree",  os.path.join(MODELS_DIR, "dtree.pkl"),  use_flat=False)
-def eval_xgb():    eval_sklearn_like("XGBoost",    os.path.join(MODELS_DIR, "XGBoost.json"),   use_flat=True)
+def eval_xgb():    eval_sklearn_like("XGBoost",    os.path.join(MODELS_DIR, "model_xgb.pkl"),   use_flat=True)
 def eval_xgbrf():  eval_sklearn_like("xgbrf",  os.path.join(MODELS_DIR, "xgbrf.pkl"),  use_flat=False)
 
 # -----------------------------
@@ -367,7 +367,7 @@ def eval_ensemble_lstm_xgb():
     lstm_path = os.path.join(MODELS_DIR, "model_lstm.pt")
     xgb_path  = os.path.join(MODELS_DIR, "model_xgb.pkl")
     if not (os.path.exists(lstm_path) and os.path.exists(xgb_path)):
-        print("[ensemble_avg] skipped (needs model_lstm.pt and model_xgb.json)."); return
+        print("[ensemble_avg] skipped (needs model_lstm.pt and model_xgb.pkl)."); return
 
     # LSTM probs
     lstm = TabularLSTM().to(DEVICE)
@@ -376,7 +376,7 @@ def eval_ensemble_lstm_xgb():
     _, probs_lstm = time_inference_ns(infer_probs_seq, lstm, test_loader, DEVICE)
 
     # XGB probs
-    xgb = XGBClassifier(); xgb.load_model(xgb_path)
+    xgb = joblib.load(xgb_path)
     def _pp(m, X): return m.predict_proba(X)[:, 1]
     _, probs_xgb = time_inference_ns(_pp, xgb, X_test_flat)
 

--- a/src/inference/generate_predictions.py
+++ b/src/inference/generate_predictions.py
@@ -74,8 +74,7 @@ def gen_xgboost():
     if os.path.exists(path):
         return
     X_train, X_val, X_test, y_train, y_val, y_test, *_ = joblib.load('preprocessed_data_v4.pkl')
-    model = XGBClassifier()
-    model.load_model('models/model_xgb.json')
+    model = joblib.load('models/model_xgb.pkl')
     probs = model.predict_proba(X_test)[:, 1]
     save_npz('XGBoost', y_test, probs)
 

--- a/src/training/train_XGBoost.py
+++ b/src/training/train_XGBoost.py
@@ -7,7 +7,7 @@ RUN_ID     = "v4"
 DATA_PATH  = "data/processed/preprocessed_data_v4.pkl"  # adjust if needed
 MODEL_DIR  = f"models/{RUN_ID}"
 MODEL_KEY  = "XGBoost"
-MODEL_PATH = os.path.join(MODEL_DIR, f"{MODEL_KEY}.json")
+MODEL_PATH = os.path.join(MODEL_DIR, "model_xgb.pkl")
 
 SEED       = 42
 os.makedirs(MODEL_DIR, exist_ok=True)
@@ -46,7 +46,7 @@ def main():
     t1_ns = time.perf_counter_ns()
 
     # 5) Save model + metadata
-    model.save_model(MODEL_PATH)
+    joblib.dump(model, MODEL_PATH)
 
     meta = {
         "run_id": RUN_ID,


### PR DESCRIPTION
## Summary
- Save standalone XGBoost models as `model_xgb.pkl` via joblib
- Evaluate XGBoost models from `model_xgb.pkl` and load ensemble members with joblib
- Update inference helper to read XGBoost predictions from the unified filename

## Testing
- `python -m py_compile src/eval/eval_all.py src/training/train_XGBoost.py src/inference/generate_predictions.py`


------
https://chatgpt.com/codex/tasks/task_b_68a751f9c380832cbf94d717b70e5110