### PR TITLE
Save LSTM model as model_lstm.pt

### DIFF
--- a/src/eval/eval_all.py
+++ b/src/eval/eval_all.py
@@ -367,7 +367,7 @@ def eval_ensemble_lstm_xgb():
     lstm_path = os.path.join(MODELS_DIR, "model_lstm.pt")
     xgb_path  = os.path.join(MODELS_DIR, "model_xgb.pkl")
     if not (os.path.exists(lstm_path) and os.path.exists(xgb_path)):
-        print("[ensemble_avg] skipped (needs model_lstm.pt and model_xgb.json)."); return
+        print("[ensemble_avg] skipped (needs model_lstm.pt and model_xgb.pkl)."); return
 
     # LSTM probs
     lstm = TabularLSTM().to(DEVICE)
@@ -376,7 +376,7 @@ def eval_ensemble_lstm_xgb():
     _, probs_lstm = time_inference_ns(infer_probs_seq, lstm, test_loader, DEVICE)
 
     # XGB probs
-    xgb = XGBClassifier(); xgb.load_model(xgb_path)
+    xgb = joblib.load(xgb_path)
     def _pp(m, X): return m.predict_proba(X)[:, 1]
     _, probs_xgb = time_inference_ns(_pp, xgb, X_test_flat)
 

--- a/src/training/train_LSTM.py
+++ b/src/training/train_LSTM.py
@@ -9,7 +9,7 @@ RUN_ID      = "v4"
 DATA_PATH   = "data/processed/preprocessed_data_v4.pkl"
 MODEL_DIR   = f"models/{RUN_ID}"
 MODEL_KEY   = "LSTM"
-MODEL_PATH  = os.path.join(MODEL_DIR, f"{MODEL_KEY}.pt")
+MODEL_PATH  = os.path.join(MODEL_DIR, "model_lstm.pt")
 
 BATCH_SIZE  = 64
 EPOCHS      = 30


### PR DESCRIPTION
## Summary
- Save LSTM training outputs to `model_lstm.pt` for consistency with evaluation and inference scripts.
- Load the XGBoost component of the LSTM+XGB ensemble from `model_xgb.pkl` using `joblib` and fix the skip message.

## Testing
- `pytest`
- `python -m src.eval.eval_all` *(fails: data/processed/preprocessed_data_v4.pkl not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d139c968832c9b455cb4d2f3b56d